### PR TITLE
STY: flake8 failures in the generated package

### DIFF
--- a/{{ cookiecutter.folder_name }}/run_tests.py
+++ b/{{ cookiecutter.folder_name }}/run_tests.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-############
-# Standard #
-############
+
 import os
 import sys
 import pytest
@@ -9,17 +7,18 @@ from pathlib import Path
 import logging
 from logging.handlers import RotatingFileHandler
 
+
 if __name__ == '__main__':
     # Show output results from every test function
     # Show the message output for skipped and expected failures
-    args = ['-v', '-vrxs']
+    args = ['-vrxs']
 
     # Add extra arguments
-    if len(sys.argv) >1:
+    if len(sys.argv) > 1:
         args.extend(sys.argv[1:])
 
     print('pytest arguments: {}'.format(args))
-    
+
     # Setup logger and log everything to a file
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
@@ -31,9 +30,10 @@ if __name__ == '__main__':
         # Create the file if it doesnt already exist
     if not log_file.exists():
         log_file.touch()
-        
+
     handler = RotatingFileHandler(str(log_file), backupCount=5,
-                                  maxBytes=1024*1024*10, encoding=None, delay=0)
+                                  maxBytes=1024*1024*10, encoding=None,
+                                  delay=0)
     formatter = logging.Formatter(fmt=('%(asctime)s.%(msecs)03d '
                                        '%(module)-10s '
                                        '%(levelname)-8s '
@@ -44,6 +44,6 @@ if __name__ == '__main__':
     root_logger.addHandler(handler)
 
     logger = logging.getLogger(__name__)
-    logger.info('pytest arguments: {}'.format(args))    
+    logger.info('pytest arguments: {}'.format(args))
 
     sys.exit(pytest.main(args))

--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/tests/test_blank.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/tests/test_blank.py
@@ -1,11 +1,12 @@
 """
-This document and it's single test are included only so that first-time builds
+This document and its single test are included only so that first-time builds
 with doctr will succeed and create an empty document.
 """
-import pytest
 import logging
+
+
 logger = logging.getLogger(__name__)
 
-def test_blank():
-    1/0
 
+def test_blank():
+    raise ZeroDivisionError()

--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/utils.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/utils.py
@@ -9,7 +9,6 @@ import inspect
 import logging
 import logging.config
 from pathlib import Path
-from logging.handlers import RotatingFileHandler
 
 ###############
 # Third Party #
@@ -19,11 +18,12 @@ import coloredlogs
 
 logger = logging.getLogger(__name__)
 
+
 class RotatingFileHandlerRelativePath(logging.handlers.RotatingFileHandler):
     """
-    Extension of the filehandler class that appends the current directory to the
-    inputted filename. This is so the log files can be found relative to this 
-    file rather than from wherever the script is run.
+    Extension of the filehandler class that appends the current directory to
+    the inputted filename. This is so the log files can be found relative to
+    this file rather than from wherever the script is run.
     """
     def __init__(self, filename, *args, **kwargs):
         filename_full = os.path.join(os.path.dirname(__file__), filename)
@@ -32,8 +32,9 @@ class RotatingFileHandlerRelativePath(logging.handlers.RotatingFileHandler):
 
 def absolute_submodule_path(submodule, cur_dir=inspect.stack()[0][1]):
     """
-    Returns the absolute path of the inputted {{ cookiecutter.repo_name }} submodule 
-    based on an inputtet absolute path, or the absolute path of this file.
+    Returns the absolute path of the `{{ cookiecutter.repo_name }}`
+    submodule based on an inputtet absolute path, or the absolute path of this
+    file.
 
     Parameters
     ----------
@@ -56,8 +57,10 @@ def absolute_submodule_path(submodule, cur_dir=inspect.stack()[0][1]):
     full_path = base_path / Path(submodule)
     return str(full_path)
 
+
 DIR_MODULE = Path(absolute_submodule_path("{{ cookiecutter.repo_name }}/"))
 DIR_LOGS = DIR_MODULE / "logs"
+
 
 def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     """
@@ -75,7 +78,7 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
 
     dir_logs : str or Path, optional
         Path to the log directory.
-        
+
     default_level : logging.LEVEL, optional
         Logging level for the default logging setup if the yaml fails.
     """
@@ -83,7 +86,7 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     if path_yaml is None:
         path_yaml = DIR_MODULE / "logging.yml"
     # Make sure we are using Path objects
-    else: 
+    else:
         path_yaml = Path(path_yaml)
     # Get the log directory
     if dir_logs is None:
@@ -91,12 +94,12 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
     # Make sure we are using Path objects
     else:
         dir_logs = Path(dir_logs)
-        
+
     # Make the log directory if it doesn't exist
-    if not dir_logs.exists(): 
+    if not dir_logs.exists():
         dir_logs.mkdir()
 
-    log_files = ['info.log', 'errors.log', 'debug.log',  'critical.log', 
+    log_files = ['info.log', 'errors.log', 'debug.log',  'critical.log',
                  'warn.log']
     for log_file in log_files:
         path_log_file = dir_logs / log_file
@@ -105,7 +108,7 @@ def setup_logging(path_yaml=None, dir_logs=None, default_level=logging.INFO):
             path_log_file.touch()
         # Set permissions to be accessible to everyone
         if path_log_file.stat().st_mode != 33279:
-            path_log_file.chmod(0o777)        
+            path_log_file.chmod(0o777)
 
     # Set up everything if the yaml file is present
     if path_yaml.exists():


### PR DESCRIPTION
We require that flake8 pass on the generated package, but we supply `utils.py` and others which contain many flake8 failures.