### PR TITLE
MNT: git over ssh should be used, not https; configurable remote name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
     "description": "A short description of the project.",
     "python_interpreter": ["python3", "python"],
     "auto_git_setup": ["no","yes"],
+    "git_remote_name": "origin",
     "use_doctr": ["no","yes"],
     "auto_versioneer_setup": ["no","yes"],
     "auto_doctr_setup": ["no","yes"]

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -2,7 +2,7 @@
 {% if cookiecutter.auto_git_setup == "yes" %}
 git init
 git add -A
-git remote add upstream https://github.com/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}.git
+git remote add {{ cookiecutter.git_remote_name }} git@github.com:{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}.git
 {% endif %}
 {% if cookiecutter.auto_versioneer_setup == "yes" %}
 versioneer install


### PR DESCRIPTION
Chances are if one is creating a new repository with this cookiecutter, it will be the canonical source of the code. That's normally named `origin` in git remotes.

Additionally, using git over ssh (with an ssh key) is preferable to https (which requires access tokens/typing in passwords).