### PR TITLE
ENH: Add codecov configuration; remove awscli requirement

### DIFF
--- a/{{ cookiecutter.folder_name }}/.codecov.yml
+++ b/{{ cookiecutter.folder_name }}/.codecov.yml
@@ -1,0 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: auto

--- a/{{ cookiecutter.folder_name }}/requirements.txt
+++ b/{{ cookiecutter.folder_name }}/requirements.txt
@@ -1,4 +1,3 @@
-awscli
 coloredlogs
 coverage
 doctr


### PR DESCRIPTION
Add codecov coverage settings.
Remove unused `awscli` default package requirement (used for Amazon AWS)