### PR TITLE
CI: Update travis and setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ The directory structure of your new project looks like this:
   │   
   ├── docs                 <- A default Sphinx project; see sphinx-doc.org for details
   │   
-  ├── docs-requirements    <- Requirements to make the sphinx documentation
+  ├── dev-requirements.txt <- Requirements to develop, make the sphinx documentation
   │   
   ├── logs                 <- Directory for log files and is not version controlled
   │  
@@ -106,6 +106,8 @@ The directory structure of your new project looks like this:
   │
   ├── Makefile             <- Makefile for the project
   │
+  ├── MANIFEST.in          <- setup.py manifest of files
+  │
   ├── README.md            <- The top-level README for developers using this project
   │
   ├── requirements.txt     <- The requirements file for reproducing the analysis environment, e.g.
@@ -122,7 +124,8 @@ Installing Development Requirements
 -----------------------------------
 ::
 
-  $ pip install -r requirements.txt
+  $ pip install -Ur requirements.txt
+  $ pip install -Ur dev-requirements.txt
 
 Running the Tests
 -----------------

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,14 +1,16 @@
 {
     "project_name": "project_name",
     "repo_name": "{{ cookiecutter.project_name.lower().replace(' ', '_') }}",
-    "author_name": "SLAC National Accelerator Laboratories",
+    "author_name": "SLAC National Accelerator Laboratory",
+    "email": "",
     "folder_name": "{{ cookiecutter.repo_name }}",
-    "github_repo_group": "{{ cookiecutter.author_name }}",
-    "import_name": "src",
+    "github_repo_group": "pcdshub",
+    "import_name": "{{ cookiecutter.repo_name }}",
     "description": "A short description of the project.",
     "python_interpreter": ["python3", "python"],
     "auto_git_setup": ["no","yes"],
     "use_doctr": ["no","yes"],
     "auto_versioneer_setup": ["no","yes"],
-    "auto_doctr_setup": ["no","yes"]
+    "auto_doctr_setup": ["no","yes"],
+    "use_x11_on_travis": ["no","yes"]
 }

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -9,7 +9,6 @@ sudo: false
 env: 
    global:
       - OFFICIAL_REPO="{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}"
-      - BUILD_DOCS=1
       {% if cookiecutter.use_doctr == "yes" %}
       - secure: ""
       {% endif %}
@@ -23,7 +22,7 @@ matrix:
   include:
     - python: 3.6
       env:
-        - CONDA_UPLOAD=1
+        - BUILD_DOCS=1
         - PCDS_CHANNEL=pcds-tag
     - python: 3.6
       env: PCDS_CHANNEL=pcds-dev
@@ -101,7 +100,7 @@ after_success:
   - codecov
 
   - |
-    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && "$CONDA_UPLOAD" == "1" ]]; then
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO ]]; then
       if [[ $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $PCDS_CHANNEL == 'pcds-tag' ]]; then
         export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
         anaconda upload bld-dir/linux-64/*.tar.bz2

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -20,39 +20,38 @@ matrix:
     - python: 3.6
       env:
         - CONDA_UPLOAD=1
-        - CONDA_CHANNEL=pcds-tag
+        - PCDS_CHANNEL=pcds-tag
     - python: 3.6
-      env: CONDA_CHANNEL=pcds-dev
+      env: PCDS_CHANNEL=pcds-dev
     - python: 3.7
-      env: CONDA_CHANNEL=pcds-tag
+      env: PCDS_CHANNEL=pcds-tag
     - python: 3.7
-      env: CONDA_CHANNEL=pcds-dev
+      env: PCDS_CHANNEL=pcds-dev
   allow_failures:
     - python: 3.7
-      env: CONDA_CHANNEL=pcds-tag
+      env: PCDS_CHANNEL=pcds-tag
     - python: 3.7
-      env: CONDA_CHANNEL=pcds-dev
+      env: PCDS_CHANNEL=pcds-dev
 
 install:
-  - sudo apt-get update
-  # We do this conditionally because it saves us some downloading if the
-  # version is the same.
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  - conda update -q conda conda-build
+  - conda config --append channels $PCDS_CHANNEL
+  - conda config --append channels conda-forge
   # Useful for debugging any issues with conda
   - conda info -a
-  #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip wheel pytest
-  #Launch Conda environment
+  # Test conda build
+  - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
+  - conda config --add channels "file://`pwd`/bld-dir"
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION {{ cookiecutter.repo_name }} --file requirements-dev.txt
   - source activate test-environment
-  #Install pedl
+
   - pip install codecov
   - pip install -r requirements.txt
-  #Install
   - pip install -e .
 
 script:
@@ -74,3 +73,14 @@ script:
 after_success:
   - coverage report -m
   - codecov
+
+  - |
+    if [[ $TRAVIS_PULL_REQUEST == false && $TRAVIS_REPO_SLUG == $OFFICIAL_REPO && "$CONDA_UPLOAD" == "1" ]]; then
+      if [[ $TRAVIS_BRANCH == $TRAVIS_TAG  && $TRAVIS_TAG != '' && $PCDS_CHANNEL == 'pcds-tag' ]]; then
+        export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_TAG
+        anaconda upload bld-dir/linux-64/*.tar.bz2
+      elif [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_TAG == '' && $PCDS_CHANNEL == 'pcds-dev' ]]; then
+        export ANACONDA_API_TOKEN=$CONDA_UPLOAD_TOKEN_DEV
+        anaconda upload bld-dir/linux-64/*.tar.bz2
+      fi
+    fi

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -51,11 +51,10 @@ install:
   # Test conda build
   - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION {{ cookiecutter.repo_name }} --file requirements-dev.txt
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION {{ cookiecutter.repo_name }} --file requirements.txt
   - source activate test-environment
 
-  - pip install codecov
-  - pip install -r requirements.txt
+  - pip install -Ur dev-requirements.txt
   - pip install -e .
 
 {% if cookiecutter.use_x11_on_travis == "yes" %}

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -56,8 +56,8 @@ install:
   - pip install -e .
 
 script:
-  - coverage run run_tests.py
   - flake8 {{ cookiecutter.repo_name }}
+  - coverage run run_tests.py
   - set -e
   {% if cookiecutter.use_doctr == "yes" %}
   - |

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -1,6 +1,10 @@
 language: python
-sudo: false
 dist: xenial
+{% if cookiecutter.use_x11_on_travis == "yes" %}
+sudo: true
+{% else %}
+sudo: false
+{% endif %}
 
 env: 
    global:
@@ -53,6 +57,20 @@ install:
   - pip install codecov
   - pip install -r requirements.txt
   - pip install -e .
+
+{% if cookiecutter.use_x11_on_travis == "yes" %}
+before_script:
+  - sudo apt-get update
+  # Install window manager
+  - sudo apt-get install -y xvfb herbstluftwm
+  # Taken from docs.travis-ci.com/user/gui-and-headless-browsers
+  - "export DISPLAY=:99.0"
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX +render -noreset"
+  - sleep 3 # give xvfb some time to start
+  # Run windows manager
+  - "herbstluftwm &"
+  - sleep 1
+{% endif %}
 
 script:
   - flake8 {{ cookiecutter.repo_name }}

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 sudo: false
+dist: xenial
 
 env: 
    global:
@@ -9,10 +10,28 @@ env:
       - secure: ""
       {% endif %}
 
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
 
-python:
-  # We don't actually use the Travis Python, but this keeps it organized.
-  - "3.6"
+matrix:
+  include:
+    - python: 3.6
+      env:
+        - CONDA_UPLOAD=1
+        - CONDA_CHANNEL=pcds-tag
+    - python: 3.6
+      env: CONDA_CHANNEL=pcds-dev
+    - python: 3.7
+      env: CONDA_CHANNEL=pcds-tag
+    - python: 3.7
+      env: CONDA_CHANNEL=pcds-dev
+  allow_failures:
+    - python: 3.7
+      env: CONDA_CHANNEL=pcds-tag
+    - python: 3.7
+      env: CONDA_CHANNEL=pcds-dev
 
 install:
   - sudo apt-get update

--- a/{{ cookiecutter.folder_name }}/.travis.yml
+++ b/{{ cookiecutter.folder_name }}/.travis.yml
@@ -38,23 +38,32 @@ matrix:
       env: PCDS_CHANNEL=pcds-dev
 
 install:
-  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  # Install and configure miniconda
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda conda-build
+
+  # Ensure all packages are up-to-date
+  - conda update -q conda
+  - conda install conda-build anaconda-client
   - conda config --append channels $PCDS_CHANNEL
   - conda config --append channels conda-forge
-  # Useful for debugging any issues with conda
   - conda info -a
-  # Test conda build
+
+  # Build the conda recipe for this package
   - conda build -q conda-recipe --python=$TRAVIS_PYTHON_VERSION --output-folder bld-dir
   - conda config --add channels "file://`pwd`/bld-dir"
+
+  # Create the test environment
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION {{ cookiecutter.repo_name }} --file requirements.txt
+  - source deactivate
   - source activate test-environment
 
+  # Install additional development requirements
   - pip install -Ur dev-requirements.txt
+  # Install the package
   - pip install -e .
 
 {% if cookiecutter.use_x11_on_travis == "yes" %}

--- a/{{ cookiecutter.folder_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.folder_name }}/dev-requirements.txt
@@ -11,3 +11,6 @@ matplotlib
 numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
+{% if cookiecutter.use_doctr == "yes" %}
+doctr
+{% endif %}

--- a/{{ cookiecutter.folder_name }}/docs-requirements.txt
+++ b/{{ cookiecutter.folder_name }}/docs-requirements.txt
@@ -1,3 +1,0 @@
-sphinx
-sphinx_rtd_theme
-doctr

--- a/{{ cookiecutter.folder_name }}/requirements-dev.txt
+++ b/{{ cookiecutter.folder_name }}/requirements-dev.txt
@@ -1,0 +1,13 @@
+# These are required for developing the package (running the tests, building
+# the documentation) but not necessarily required for _using_ it.
+codecov
+coverage
+flake8
+pytest
+sphinx
+# These are dependencies of various sphinx extensions for documentation.
+ipython
+matplotlib
+numpydoc
+sphinx-copybutton
+sphinx_rtd_theme

--- a/{{ cookiecutter.folder_name }}/setup.py
+++ b/{{ cookiecutter.folder_name }}/setup.py
@@ -31,6 +31,14 @@ with open(path.join(here, 'requirements.txt')) as requirements_file:
                     if not line.startswith('#')]
 
 
+git_requirements = [r for r in requirements if r.startswith('git+')]
+if git_requirements:
+    print('User must install the following packages manually:')
+    print()
+    print("\n".join(f'* {r}' for r in git_requirements))
+    print()
+
+
 setup(
     name='{{ cookiecutter.repo_name }}',
     version=versioneer.get_version(),

--- a/{{ cookiecutter.folder_name }}/setup.py
+++ b/{{ cookiecutter.folder_name }}/setup.py
@@ -1,11 +1,63 @@
 import versioneer
+from os import path
 from setuptools import setup, find_packages
+import sys
 
-setup(name='{{ cookiecutter.repo_name }}',
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      license='BSD',
-      author='{{ cookiecutter.author_name }}',
-      packages=find_packages(),
-      description='{{ cookiecutter.description }}',
-      )
+min_version = (3, 5)
+
+if sys.version_info < min_version:
+    error = """
+{{ cookiecutter.package_dist_name }} does not support Python {0}.{1}.
+Python {2}.{3} and above is required. Check your Python version like so:
+
+python3 --version
+
+This may be due to an out-of-date pip. Make sure you have pip >= 9.0.1.
+Upgrade pip like so:
+
+pip install --upgrade pip
+""".format(*sys.version_info[:2], *min_version)
+    sys.exit(error)
+
+
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, 'README.rst'), encoding='utf-8') as readme_file:
+    readme = readme_file.read()
+
+with open(path.join(here, 'requirements.txt')) as requirements_file:
+    # Parse requirements.txt, ignoring any commented-out lines.
+    requirements = [line for line in requirements_file.read().splitlines()
+                    if not line.startswith('#')]
+
+
+setup(
+    name='{{ cookiecutter.repo_name }}',
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    license='BSD',
+    author='{{ cookiecutter.author_name }}',
+    packages=find_packages(exclude=['docs', 'tests']),
+    description='{{ cookiecutter.description }}',
+    long_description=readme,
+    url='https://github.com/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}',
+    entry_points={
+        'console_scripts': [
+            # 'some.module:some_function',
+            ],
+        },
+    include_package_data=True,
+    package_data={
+        '{{ cookiecutter.package_dir_name }}': [
+            # When adding files here, remember to update MANIFEST.in as well,
+            # or else they will not be included in the distribution on PyPI!
+            # 'path/to/data_file',
+            ]
+        },
+    install_requires=requirements,
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+    ],
+)

--- a/{{ cookiecutter.folder_name }}/setup.py
+++ b/{{ cookiecutter.folder_name }}/setup.py
@@ -7,7 +7,7 @@ min_version = (3, 5)
 
 if sys.version_info < min_version:
     error = """
-{{ cookiecutter.package_dist_name }} does not support Python {0}.{1}.
+{{ cookiecutter.repo_name }} does not support Python {0}.{1}.
 Python {2}.{3} and above is required. Check your Python version like so:
 
 python3 --version
@@ -56,7 +56,7 @@ setup(
         },
     include_package_data=True,
     package_data={
-        '{{ cookiecutter.package_dir_name }}': [
+        '{{ cookiecutter.import_name }}': [
             # When adding files here, remember to update MANIFEST.in as well,
             # or else they will not be included in the distribution on PyPI!
             # 'path/to/data_file',

--- a/{{ cookiecutter.folder_name }}/setup.py
+++ b/{{ cookiecutter.folder_name }}/setup.py
@@ -3,7 +3,7 @@ from os import path
 from setuptools import setup, find_packages
 import sys
 
-min_version = (3, 5)
+min_version = (3, 6)
 
 if sys.version_info < min_version:
     error = """


### PR DESCRIPTION
setup.py
* Split requirements a bit better - `dev-requirements` and `requirements`
* Add in a bunch of things from https://github.com/NSLS-II/scientific-python-cookiecutter
* Better stub out `setup()`
* Add minimum Python version requirement - hard-coded 3.5 for now (could be configurable as the NSLS-II one is)
* `git_requirements` blurb from typhon

cookiecutter.json
* "SLAC National Accelerator Laboratories" is not really a thing...
* make import_name default to repo_name (`src` is not good)

Travis:
* Add X11 server option, as this is frequently copy/pasted for our GUI-related projects
* Make sudo necessary only if using X11
* Address conda uploading of #2 
* PCDS channel testing matrix on 3.6 and 3.7