### PR TITLE
Remove reference to landscape.yml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,6 @@ The directory structure of your new project looks like this:
   │
   ├── .gitignore           <- Gitignore for the repo
   │
-  ├── .landscape.yml       <- Yaml file for Landscape continuous code metrics
-  │
   ├── .logging.yml         <- Yaml file for the logger
   │
   ├── .travis.yml          <- Yaml file for travis continuous integration


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Docs should no longer specify the creation of landscape.yml as landscape.yml creation was deprecated some time ago. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The docs lie!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It's a readme.rst. 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
it *is* documentation.
<!--
## Screenshots (if appropriate):
-->
