### PR TITLE
MNT: No versioneer, docs tweaks

### DIFF
--- a/{{ cookiecutter.folder_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.folder_name }}/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,11 +18,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.7.9
+    rev: 3.9.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.5.1
+    rev: 5.8.0
     hooks:
     -   id: isort

--- a/{{ cookiecutter.folder_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.folder_name }}/dev-requirements.txt
@@ -11,4 +11,5 @@ numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
 doctr
+docs-versions-menu
 recommonmark

--- a/{{ cookiecutter.folder_name }}/docs/source/conf.py
+++ b/{{ cookiecutter.folder_name }}/docs/source/conf.py
@@ -45,15 +45,17 @@ release = ""
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    "sphinx.ext.autodoc",
-    "sphinx.ext.todo",
-    "sphinx.ext.coverage",
-    "sphinx.ext.mathjax",
-    "sphinx.ext.viewcode",
-    "sphinx.ext.githubpages",
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.inheritance_diagram',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
     "numpydoc",
     "recommonmark",
-    "doctr_versions_menu",
+    "docs_versions_menu",
     "sphinx_rtd_theme",
 ]
 
@@ -84,6 +86,11 @@ language = None
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = []
 
+# The reST default role (used for this markup: `text`) to use for all
+# documents.
+#
+default_role = 'any'
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
@@ -100,6 +107,9 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 #
 # html_theme_options = {}
+
+# html_css_files = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -120,7 +130,7 @@ html_static_path = ["_static"]
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "cookiecutterproject_namedoc"
+htmlhelp_basename = "{{ cookiecutter.project_name }}_namedoc"
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -186,10 +196,19 @@ texinfo_documents = [
     ),
 ]
 
-
 # -- Extension configuration -------------------------------------------------
 
-# -- Options for todo extension ----------------------------------------------
+# Intersphinx
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}
 
-# If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
+
+# Inheritance diagram settings
+inheritance_graph_attrs = dict(
+    rankdir="TB",
+    size='""',
+)
+
+inheritance_alias = {
+}

--- a/{{ cookiecutter.folder_name }}/requirements.txt
+++ b/{{ cookiecutter.folder_name }}/requirements.txt
@@ -1,1 +1,1 @@
-versioneer
+# List requirements here.


### PR DESCRIPTION
* Remove versioneer from "run" requirements (or `pip install mypackage`-requirements). Auto versioneer setup vendors it along with `_version.py`, so it's unnecessary
* `doctr-versions-menu` -> `docs-versions-menu`
* Minor sphinx config updates