### PR TITLE
ENH: add entrypoint with subcommand framework

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore =
+exclude = .git,__pycache__
+max-line-length = 115

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -14,15 +14,15 @@ repos:
     -   id: check-symlinks
     -   id: check-xml
     -   id: check-yaml
-        exclude: '^(.*/conda-recipe/meta.yaml|{{ cookiecutter.folder_name }}/.travis.yml)$'
+        exclude: '^(conda-recipe/meta.yaml)$'
     -   id: debug-statements
 
 -   repo: https://gitlab.com/pycqa/flake8.git
-    rev: 3.8.3
+    rev: 3.9.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.5.2
+    rev: 5.8.0
     hooks:
     -   id: isort

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -5,6 +5,7 @@ git add -A
 git remote add {{ cookiecutter.git_remote_name }} git@github.com:{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}.git
 {% endif %}
 {% if cookiecutter.auto_versioneer_setup == "yes" %}
+pip install versioneer
 versioneer install
 {% endif %}
 {% if cookiecutter.auto_doctr_setup == "yes" %}

--- a/{{ cookiecutter.folder_name }}/setup.py
+++ b/{{ cookiecutter.folder_name }}/setup.py
@@ -51,18 +51,18 @@ setup(
     long_description=readme,
     url='https://github.com/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}',  # noqa
     entry_points={
-        'console_scripts': [
-            # '{{ cookiecutter.repo_name }}={{ cookiecutter.import_name }}.__main__:main',  # noqa
-            ],
-        },
+        "console_scripts": [
+            "{{ cookiecutter.repo_name }}={{ cookiecutter.import_name }}.bin.main:main",
+        ],
+    },
     include_package_data=True,
     package_data={
         '{{ cookiecutter.import_name }}': [
             # When adding files here, remember to update MANIFEST.in as well,
             # or else they will not be included in the distribution on PyPI!
             # 'path/to/data_file',
-            ]
-        },
+        ]
+    },
     install_requires=requirements,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/__init__.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/__init__.py
@@ -1,0 +1,3 @@
+from .main import main
+
+__all__ = ["main"]

--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/help.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/help.py
@@ -1,0 +1,27 @@
+"""
+`{{cookiecutter.import_name}} help` will show detailed help information.
+"""
+
+import argparse
+
+DESCRIPTION = __doc__
+
+
+def build_arg_parser(argparser=None):
+    if argparser is None:
+        argparser = argparse.ArgumentParser()
+
+    argparser.description = DESCRIPTION
+    argparser.formatter_class = argparse.RawTextHelpFormatter
+
+    argparser.add_argument(
+        'argument_name',
+        type=str,
+        help='Get help on this.',
+    )
+
+    return argparser
+
+
+def main(argument_name):
+    print(f"This should show help for {argument_name!r}.")

--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/main.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/bin/main.py
@@ -1,0 +1,98 @@
+"""
+`{{cookiecutter.import_name}}` is the top-level command for accessing various subcommands.
+
+Try:
+
+"""
+
+import argparse
+import importlib
+import logging
+
+import {{cookiecutter.import_name}}
+
+DESCRIPTION = __doc__
+
+
+MODULES = ("help", )
+
+
+def _try_import(module):
+    relative_module = f'.{module}'
+    return importlib.import_module(relative_module, '{{cookiecutter.import_name}}.bin')
+
+
+def _build_commands():
+    global DESCRIPTION
+    result = {}
+    unavailable = []
+
+    for module in sorted(MODULES):
+        try:
+            mod = _try_import(module)
+        except Exception as ex:
+            unavailable.append((module, ex))
+        else:
+            result[module] = (mod.build_arg_parser, mod.main)
+            DESCRIPTION += f'\n    $ {{cookiecutter.import_name}} {module} --help'
+
+    if unavailable:
+        DESCRIPTION += '\n\n'
+
+        for module, ex in unavailable:
+            DESCRIPTION += (
+                f'\nWARNING: "{{cookiecutter.import_name}} {module}" is unavailable due to:'
+                f'\n\t{ex.__class__.__name__}: {ex}'
+            )
+
+    return result
+
+
+COMMANDS = _build_commands()
+
+
+def main():
+    top_parser = argparse.ArgumentParser(
+        prog='{{cookiecutter.import_name}}',
+        description=DESCRIPTION,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    top_parser.add_argument(
+        '--version', '-V',
+        action='version',
+        version={{cookiecutter.import_name}}.__version__,
+        help="Show the {{cookiecutter.import_name}} version number and exit."
+    )
+
+    top_parser.add_argument(
+        '--log', '-l', dest='log_level',
+        default='INFO',
+        type=str,
+        help='Python logging level (e.g. DEBUG, INFO, WARNING)'
+    )
+
+    subparsers = top_parser.add_subparsers(help='Possible subcommands')
+    for command_name, (build_func, main) in COMMANDS.items():
+        sub = subparsers.add_parser(command_name)
+        build_func(sub)
+        sub.set_defaults(func=main)
+
+    args = top_parser.parse_args()
+    kwargs = vars(args)
+    log_level = kwargs.pop('log_level')
+
+    logger = logging.getLogger('{{cookiecutter.import_name}}')
+    logger.setLevel(log_level)
+    logging.basicConfig()
+
+    if hasattr(args, 'func'):
+        func = kwargs.pop('func')
+        logger.debug('%s(**%r)', func.__name__, kwargs)
+        func(**kwargs)
+    else:
+        top_parser.print_help()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a handy package entrypoint pattern I've been following for a while. I think it could be of general utility.

With the default settings, this cookiecutter then allows for this:

```
project_name klauer$ project_name --help
usage: project_name [-h] [--version] [--log LOG_LEVEL] {help} ...

`project_name` is the top-level command for accessing various subcommands.

Try:

    $ project_name help --help

positional arguments:
  {help}                Possible subcommands

optional arguments:
  -h, --help            show this help message and exit
  --version, -V         Show the project_name version number and exit.
  --log LOG_LEVEL, -l LOG_LEVEL
                        Python logging level (e.g. DEBUG, INFO, WARNING)
project_name klauer$ project_name help test
This should show help for 'test'.
```