### PR TITLE
ENH: ignore OS-specific annoying files

### DIFF
--- a/{{ cookiecutter.folder_name }}/.gitignore
+++ b/{{ cookiecutter.folder_name }}/.gitignore
@@ -107,6 +107,7 @@ ENV/
 /logs/*
 
 # OS-specific files:
+.DS_Store
 .DS_Store?
 Icon?
 Thumbs.db

--- a/{{ cookiecutter.folder_name }}/.gitignore
+++ b/{{ cookiecutter.folder_name }}/.gitignore
@@ -105,3 +105,8 @@ ENV/
 
 # None of the logs
 /logs/*
+
+# OS-specific files:
+.DS_Store?
+Icon?
+Thumbs.db


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Update the default gitignore listing with files generated on specific operating systems.

## Motivation and Context
`.DS_Store` and `Thumbs.db` get created annoyingly on macOS. Ignore those in new projects.
