### PR TITLE
DOC: update template docs and minimum Python version notes

### DIFF
--- a/{{ cookiecutter.folder_name }}/.github/workflows/standard.yml
+++ b/{{ cookiecutter.folder_name }}/.github/workflows/standard.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   standard:
-    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml
+    uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
     with:
       # The workflow needs to know the package name.  This can be determined
       # automatically if the repository name is the same as the import name.

--- a/{{ cookiecutter.folder_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.folder_name }}/CONTRIBUTING.rst
@@ -63,7 +63,7 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for loc
 
 3. Install your local copy into a new conda environment. Assuming you have conda installed, this is how you set up your fork for local development::
 
-    $ conda create -n {{ cookiecutter.repo_name }} python=3.7
+    $ conda create -n {{ cookiecutter.repo_name }} python=3.9 pip
     $ cd {{ cookiecutter.repo_name }}/
     $ pip install -e .
 
@@ -73,13 +73,14 @@ Ready to contribute? Here's how to set up `{{ cookiecutter.repo_name }}` for loc
 
    Now you can make your changes locally.
 
-5. When you're done making changes, check that your changes pass flake8::
+5. Install and enable ``pre-commit`` for this repository::
 
-    $ flake8 {{ cookiecutter.import_name }}
+    $ pip install pre-commit
+    $ pre-commit install
 
 6. Add new tests for any additional functionality or bugs you may have discovered.  And, of course, be sure that all previous tests still pass by running::
 
-    $ python run_tests.py -v
+    $ pytest -v
 
 7. Commit your changes and push your branch to GitHub::
 
@@ -98,6 +99,5 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put your
    new functionality into a function with a docstring, and add the feature to
    the list in README.rst.
-3. The pull request should work for Python 3.5 and up. Check
-   https://travis-ci.org/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}/pull_requests
+3. The pull request should work for Python 3.9 and up. Check the GitHub Actions status
    and make sure that the tests pass for all supported Python versions.

--- a/{{ cookiecutter.folder_name }}/README.rst
+++ b/{{ cookiecutter.folder_name }}/README.rst
@@ -2,41 +2,28 @@
 {{ cookiecutter.project_name }}
 ===============================
 
-.. image:: https://img.shields.io/travis/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}.svg
-        :target: https://travis-ci.org/{{ cookiecutter.github_repo_group }}/{{ cookiecutter.repo_name }}
-
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.repo_name }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}
 
 
+`Documentation <https://{{ cookiecutter.github_repo_group }}.github.io/{{ cookiecutter.repo_name}}/>`_
+
 {{ cookiecutter.description }}
-
-Documentation
--------------
-
-Sphinx-generated documentation for this project can be found here:
-https://{{ cookiecutter.github_repo_group }}.github.io/{{ cookiecutter.repo_name}}/
-
 
 Requirements
 ------------
 
-Describe the project requirements (i.e. Python version, packages and how to install them)
+* Python 3.9+
 
 Installation
 ------------
 
-Describe the installation procedure
+::
+
+  $ pip install .
 
 Running the Tests
 -----------------
 ::
 
-  $ python run_tests.py
-
-Directory Structure
--------------------
-
-This repo is based the PCDS python cookiecutter. See the following github page for more info:
-
-- `cookiecutter-pcds-python <https://github.com/pcdshub/cookiecutter-pcds-python>`_
+  $ pytest -v

--- a/{{ cookiecutter.folder_name }}/conda-recipe/meta.yaml
+++ b/{{ cookiecutter.folder_name }}/conda-recipe/meta.yaml
@@ -17,11 +17,11 @@ build:
 
 requirements:
   build:
-    - python >=3.7
+    - python >=3.9
     - pip
     - setuptools_scm
   run:
-    - python >=3.7
+    - python >=3.9
 
 test:
   imports:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Fixes:
* Stale documentation referring to Travis
* Stale documentation referring to old Python versions
* Stale documentation referring to `run_tests.py`
* pcds-ci-helpers branch/tag missing for workflow

I'm not 100% on the badge/shield replacement with shared workflows on GitHub Actions... Need to look into that