### PR TITLE
ENH: make version checker sensitive to symbolic links

### DIFF
--- a/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/version.py
+++ b/{{ cookiecutter.folder_name }}/{{ cookiecutter.import_name }}/version.py
@@ -22,17 +22,20 @@ class VersionProxy(UserString):
     4. A fallback in case none of the above match - resulting in a version of
         0.0.unknown
     """
+
     def __init__(self):
         self._version = None
 
     def _get_version(self) -> Optional[str]:
         # Checking for directory is faster than failing out of get_version
-        repo_root = Path(__file__).resolve().parent.parent
+        here = Path(__file__).resolve()
+        repo_root = here.parent.parent
         if (repo_root / ".git").exists() or (repo_root / ".git_archival.txt").exists():
             try:
                 # Git checkout
                 from setuptools_scm import get_version
-                return get_version(root="..", relative_to=__file__)
+
+                return get_version(root="..", relative_to=here)
             except (ImportError, LookupError):
                 ...
 
@@ -40,6 +43,7 @@ class VersionProxy(UserString):
         # done a build at least once.
         try:
             from ._version import version  # noqa: F401
+
             return version
         except ImportError:
             ...
@@ -51,7 +55,7 @@ class VersionProxy(UserString):
         # This is accessed by UserString to allow us to lazily fill in the
         # information
         if self._version is None:
-            self._version = self._get_version() or '0.0.unknown'
+            self._version = self._get_version() or "0.0.unknown"
 
         return self._version
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Re-use the update to `version.py` from https://github.com/pcdshub/pytmc/pull/308
This makes sure we resolve symbolic links before looking for the git directory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for certain symbolic link/pythonpath setups to get the correct version string

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
with pytmc

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
n/a
<!--
## Screenshots (if appropriate):
-->
