### PR TITLE
BLD: update cookiecutter to match ci-helpers

### DIFF
--- a/{{ cookiecutter.folder_name }}/dev-requirements.txt
+++ b/{{ cookiecutter.folder_name }}/dev-requirements.txt
@@ -1,3 +1,4 @@
 # These are required for developing the package (running the tests) but not
 # necessarily required for _using_ it.
 pytest
+pytest-cov

--- a/{{ cookiecutter.folder_name }}/pyproject.toml
+++ b/{{ cookiecutter.folder_name }}/pyproject.toml
@@ -47,3 +47,10 @@ file = [ "requirements.txt",]
 
 [tool.setuptools.dynamic.optional-dependencies.test]
 file = "dev-requirements.txt"
+
+[tool.setuptools.dynamic.optional-dependencies.doc]
+file = "docs-requirements.txt"
+
+[tool.pytest.ini_options]
+addopts = "--cov=."
+


### PR DESCRIPTION
## Description
Update the cookiecutter to use pyproject conventions for extra dependencies

## Motivation and Context
Stemming from https://github.com/pcdshub/pytmc/pull/315, which led to us deciding to have ci install extra dependencies via the `pip install .[docs, test]` pattern (https://github.com/pcdshub/pcds-ci-helpers/pull/127)

This change needs to be propagated to all our other projects, but I figure this can be a source of truth.

I omitted the `sphinx_rtd_theme>=1.2.0` in the (possibly misguided hope) that it would become obsolete soon.

The original checklist:
- add to pyproject.toml (if it doesn't exist)
  - the [tool.setuptools.dynamic.optional-dependencies.doc] section pointing to docs-requirements.txt
  - the [tool.setuptools.dynamic.optoinal-dependencies.test] section pointing to dev-requirements.txt
  - the [tool.pytest.ini_options] section containing addopts = "--cov=."
- add pytest-cov to dev-requirements.txt
- add docs-version-menu to docs-requirements.txt
- pin sphinx_rtd_theme>=1.2.0 (not related to this PR directly, but necessary)

## How Has This Been Tested?
Zach tried these changes a bunch, I'll try them out in other packages too

## Where Has This Been Documented?
This PR