### PR TITLE
FIX: secret propagation in GitHub Actions for conda releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,11 +18,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.9.0
+    rev: 6.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
     -   id: isort

--- a/{{ cookiecutter.folder_name }}/.github/workflows/standard.yml
+++ b/{{ cookiecutter.folder_name }}/.github/workflows/standard.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   standard:
     uses: pcdshub/pcds-ci-helpers/.github/workflows/python-standard.yml@master
+    secrets: inherit
     with:
       # The workflow needs to know the package name.  This can be determined
       # automatically if the repository name is the same as the import name.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Secrets need to be propagated to the shared CI jobs in order to publish to anaconda.org/pypi
* _Inherit secrets with this one simple line_!

## Motivation and Context
See hxrsnd, where we forgot this again https://github.com/pcdshub/hxrsnd/pull/125

I'll update the migration tools to this latest commit after