### PR TITLE
MNT: add codeowners to cookiecutter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,11 +18,11 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
     -   id: isort

--- a/{{ cookiecutter.folder_name }}/.github/CODEOWNERS
+++ b/{{ cookiecutter.folder_name }}/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# default group
+* @pcdshub/software-admin
+
+# github folder holds administrative files
+.github/** @pcdshub/software-admin


### PR DESCRIPTION
## Description
Adds a skeleton CODEOWNERS file to the cookiecutter contents

Note, this is different from the other PR's codeowner file (autogenerated PR), which is meant to control the contents of this repo specifically

## Motivation and Context
Have people add these CODEOWNER files by default

## How Has This Been Tested?
Not really

## Where Has This Been Documented?
This PR