### PR TITLE
FIX: move ruff import rule to config so that pre-commit checks all project rules

### DIFF
--- a/.github/workflows/cookiecutter-test.yml
+++ b/.github/workflows/cookiecutter-test.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   pip-test:
     name: "Python 3.9: pip"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:
@@ -122,7 +122,7 @@ jobs:
 
   conda-test:
     name: "Python 3.9: conda"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/{{ cookiecutter.folder_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.folder_name }}/.pre-commit-config.yaml
@@ -26,6 +26,6 @@ repos:
   rev: v0.6.3
   hooks:
   - id: ruff  # run the linter
-    args: [ --fix, --select, I ]  # --select I sorts imports
+    args: [ --fix ]  # and the safe fixes
   - id: ruff-format  # run the formatter
 

--- a/{{ cookiecutter.folder_name }}/pyproject.toml
+++ b/{{ cookiecutter.folder_name }}/pyproject.toml
@@ -59,7 +59,7 @@ line-length = 88
 exclude = [".git", "__pycache__", "build", "dist", "{{ cookiecutter.import_name }}/_version.py"]
 
 [tool.ruff.lint]
-select = ["C", "E", "F", "W", "B"]
+select = ["C", "E", "F", "W", "B", "I"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This `--select I` command in the pre-commit config actually replaces our project's ruff options! So, pre-commit isn't running all of our configured rules!
Instead, run ruff without `--select` to include all of our rules in the pyproject.toml, so they all get picked up during pre-commit. Then each project can decide which rules to follow as needed.

On the side: I'm testing the N (pep8) and ANN (missing annotations) rulesets- if I end up thinking they are useful I'll make another PR here to make them our default, if they end up being annoying I will not.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I kept seeing PRs passing in `bsmtraj` when they would fail `ruff` in my IDE, this is why.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively only

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here only

<!--
## Screenshots (if appropriate):
-->
