### PR TITLE
CI/AUTO: SHA Pinning and Dependabot

### DIFF
--- a/.github/dependabot_template.yml
+++ b/.github/dependabot_template.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+      exclude:
+      - pcdshub/pcds-ci-helpers/*

--- a/.github/workflows/cookiecutter-test.yml
+++ b/.github/workflows/cookiecutter-test.yml
@@ -40,11 +40,11 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
       with:
         python-version: "3.9"
 
@@ -115,7 +115,7 @@ jobs:
 
     - name: Upload the built package as an artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: "pip - Cookiecutter Output"
         path: ~/project_name
@@ -134,7 +134,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         fetch-depth: 0
 
@@ -211,7 +211,7 @@ jobs:
           2>&1 | tee $HOME/logs/mambabuild.txt
 
     - name: Upload the built package as an artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
       with:
         name: Python 3.9 - conda - package
         path: ~/conda-bld


### PR DESCRIPTION

# SHA Pinning

We are now required to pin GitHub Actions to specific SHAs.
This PR automatically updates all actions to a somewhat recent SHA.
It also configures dependabot to update the SHAs for us on a monthly basis.

If this PR is not merged, all GitHub Actions Workflows in this repository
will stop working at the end of June 2026.

See https://jira.slac.stanford.edu/browse/ECS-10557

## Code Review

For reviewers: our task is to pick one of:

- Merge as-is, then fix the CI if needed
- Fix the CI, and then merge
- Close this PR and archive the repo
- Merge this PR and archive the repo
- Remove the GitHub Actions configuration from the repo,
  then close this PR.
- Ignore this PR until we use the repo again
